### PR TITLE
Multitask regression

### DIFF
--- a/chemberta/masked-lm/train_roberta_regression.py
+++ b/chemberta/masked-lm/train_roberta_regression.py
@@ -94,7 +94,9 @@ def main(argv):
         num_attention_heads=FLAGS.num_attention_heads,
         num_hidden_layers=FLAGS.num_hidden_layers,
         type_vocab_size=FLAGS.type_vocab_size,
-        num_labels=dataset.num_labels
+        num_labels=dataset.num_labels,
+        norm_mean=dataset.norm_mean,
+        norm_std=dataset.norm_std,
     )
     
     model = RobertaForRegression(config=config)

--- a/chemberta/masked-lm/train_roberta_regression.py
+++ b/chemberta/masked-lm/train_roberta_regression.py
@@ -1,10 +1,8 @@
 """ Script for training a Roberta Masked-Language Model
 
-Usage [SMILES tokenizer]:
-    python train_roberta_regression.py --dataset_path=<DATASET_PATH> --output_dir=<OUTPUT_DIR> --model_name=<MODEL_NAME> --tokenizer_type=smiles --tokenizer_path="seyonec/SMILES_tokenized_PubChem_shard00_160k"
-    
-Usage [BPE tokenizer]:
-    python train_roberta_mlm.py --dataset_path=<DATASET_PATH> --output_dir=<OUTPUT_DIR> --model_name=<MODEL_NAME> --tokenizer_type=bpe
+Usage:
+    python train_roberta_regression.py --dataset_path=<DATASET_PATH> --output_dir=<OUTPUT_DIR> --model_name=<MODEL_NAME> --tokenizer_type=<smiles/bpe>
+
 """
     
 import torch

--- a/chemberta/masked-lm/train_roberta_regression.py
+++ b/chemberta/masked-lm/train_roberta_regression.py
@@ -21,7 +21,7 @@ from transformers import RobertaConfig, RobertaTokenizerFast, RobertaForMaskedLM
 
 from chemberta.utils.roberta_regression import RobertaForRegression
 from chemberta.utils.data_collators import multitask_data_collator
-from chemberta.utils.raw_text_dataset import RawTextDataset, RegressionDataset, RegressionDatasetNew
+from chemberta.utils.raw_text_dataset import RawTextDataset, RegressionDataset, RegressionDatasetLazy
 
 from transformers import DataCollatorForLanguageModeling
 from transformers import Trainer, TrainingArguments

--- a/chemberta/masked-lm/train_roberta_regression.py
+++ b/chemberta/masked-lm/train_roberta_regression.py
@@ -20,8 +20,9 @@ import torch
 
 import wandb
 from transformers import RobertaConfig, RobertaTokenizerFast, RobertaForMaskedLM
-from chemberta.utils.roberta_regression import RobertaForRegression, multitask_data_collator
 
+from chemberta.utils.roberta_regression import RobertaForRegression
+from chemberta.utils.data_collators import multitask_data_collator
 from chemberta.utils.raw_text_dataset import RawTextDataset, RegressionDataset
 
 from transformers import DataCollatorForLanguageModeling

--- a/chemberta/masked-lm/train_roberta_regression.py
+++ b/chemberta/masked-lm/train_roberta_regression.py
@@ -1,4 +1,4 @@
-""" Script for training a Roberta Masked-Language Model
+""" Script for training a Roberta Regression Model (single or multi-task)
 
 Usage:
     python train_roberta_regression.py --dataset_path=<DATASET_PATH> --output_dir=<OUTPUT_DIR> --model_name=<MODEL_NAME> --tokenizer_type=<smiles/bpe>

--- a/chemberta/masked-lm/train_roberta_regression.py
+++ b/chemberta/masked-lm/train_roberta_regression.py
@@ -31,7 +31,7 @@ from tokenizers import ByteLevelBPETokenizer
 FLAGS = flags.FLAGS
 
 # RobertaConfig params
-flags.DEFINE_integer(name="vocab_size", default=52_000, help="")
+flags.DEFINE_integer(name="vocab_size", default=512, help="")
 flags.DEFINE_integer(name="max_position_embeddings", default=512, help="")
 flags.DEFINE_integer(name="num_attention_heads", default=12, help="")
 flags.DEFINE_integer(name="num_hidden_layers", default=6, help="")

--- a/chemberta/masked-lm/train_roberta_regression.py
+++ b/chemberta/masked-lm/train_roberta_regression.py
@@ -4,7 +4,7 @@ Usage:
     python train_roberta_regression.py --dataset_path=<DATASET_PATH> --output_dir=<OUTPUT_DIR> --model_name=<MODEL_NAME> --tokenizer_type=<smiles/bpe>
 
 """
-    
+
 import torch
 import pandas as pd
 
@@ -57,7 +57,7 @@ flags.DEFINE_float(name="mlm_probability", default=0.15, lower_bound=0.0, upper_
 # Train params
 flags.DEFINE_boolean(name="overwrite_output_dir", default=True, help="")
 flags.DEFINE_integer(name="num_train_epochs", default=10, help="")
-flags.DEFINE_integer(name="per_device_train_batch_size", default=32, help="")
+flags.DEFINE_integer(name="per_device_train_batch_size", default=16, help="")
 flags.DEFINE_integer(name="save_steps", default=10_000, help="")
 flags.DEFINE_integer(name="save_total_limit", default=2, help="")
 
@@ -67,14 +67,14 @@ flags.mark_flag_as_required('dataset_path')
 def main(argv):
     #wandb.login()
     is_gpu = torch.cuda.is_available()
-        
+
     if FLAGS.tokenizer_path:
         tokenizer_path = FLAGS.tokenizer_path
     elif FLAGS.tokenizer_type.upper() == "BPE":
         tokenizer_path = FLAGS.output_tokenizer_dir
         if not os.path.isdir(tokenizer_path):
             os.makedirs(tokenizer_path)
-        
+
         tokenizer = ByteLevelBPETokenizer()
         tokenizer.train(files=FLAGS.dataset_path, vocab_size=FLAGS.vocab_size, min_frequency=FLAGS.BPE_min_frequency, special_tokens=["<s>","<pad>","</s>","<unk>","<mask>"])
         tokenizer.save_model(tokenizer_path)
@@ -85,7 +85,7 @@ def main(argv):
     tokenizer = RobertaTokenizerFast.from_pretrained(tokenizer_path, max_len=FLAGS.max_tokenizer_len)
     print("making dataset")
     dataset = RegressionDataset(tokenizer=tokenizer, file_path=FLAGS.dataset_path, block_size=FLAGS.tokenizer_block_size)
-    
+
     config = RobertaConfig(
         vocab_size=FLAGS.vocab_size,
         max_position_embeddings=FLAGS.max_position_embeddings,
@@ -96,7 +96,7 @@ def main(argv):
         norm_mean=dataset.norm_mean,
         norm_std=dataset.norm_std,
     )
-    
+
     model = RobertaForRegression(config=config)
 
     training_args = TrainingArguments(

--- a/chemberta/masked-lm/train_roberta_regression.py
+++ b/chemberta/masked-lm/train_roberta_regression.py
@@ -1,0 +1,121 @@
+""" Script for training a Roberta Masked-Language Model
+
+Usage [SMILES tokenizer]:
+    python train_roberta_mlm.py --dataset_path=<DATASET_PATH> --output_dir=<OUTPUT_DIR> --model_name=<MODEL_NAME> --tokenizer_type=smiles --tokenizer_path="seyonec/SMILES_tokenized_PubChem_shard00_160k"
+    
+Usage [BPE tokenizer]:
+    python train_roberta_mlm.py --dataset_path=<DATASET_PATH> --output_dir=<OUTPUT_DIR> --model_name=<MODEL_NAME> --tokenizer_type=bpe
+"""
+    
+import torch
+import pandas as pd
+
+import os
+from absl import app
+from absl import flags
+
+import transformers
+
+import torch
+
+import wandb
+from transformers import RobertaConfig, RobertaTokenizerFast, RobertaForMaskedLM
+from chemberta.utils.roberta_regression import RobertaForRegression, multitask_data_collator
+
+from chemberta.utils.raw_text_dataset import RawTextDataset, RegressionDataset
+
+from transformers import DataCollatorForLanguageModeling
+from transformers import Trainer, TrainingArguments
+
+from tokenizers import ByteLevelBPETokenizer
+
+FLAGS = flags.FLAGS
+
+# RobertaConfig params
+flags.DEFINE_integer(name="vocab_size", default=52_000, help="")
+flags.DEFINE_integer(name="max_position_embeddings", default=512, help="")
+flags.DEFINE_integer(name="num_attention_heads", default=12, help="")
+flags.DEFINE_integer(name="num_hidden_layers", default=6, help="")
+flags.DEFINE_integer(name="type_vocab_size", default=1, help="")
+
+# Tokenizer params
+flags.DEFINE_enum(name="tokenizer_type", default="smiles", enum_values=["smiles", "bpe", "SMILES", "BPE"], help="")
+flags.DEFINE_string(name="tokenizer_path", default="", help="")
+flags.DEFINE_integer(name="BPE_min_frequency", default=2, help="")
+flags.DEFINE_string(name="output_tokenizer_dir", default="tokenizer_dir", help="")
+flags.DEFINE_integer(name="max_tokenizer_len", default=512, help="")
+flags.DEFINE_integer(name="tokenizer_block_size", default=512, help="")
+
+
+# Dataset params
+flags.DEFINE_string(name="dataset_path", default="pubchem-10m.txt", help="")
+flags.DEFINE_string(name="output_dir", default="PubChem_10M_SMILES_Tokenizer", help="")
+flags.DEFINE_string(name="model_name", default="PubChem_10M_SMILES_Tokenizer", help="")
+
+# MLM params
+flags.DEFINE_float(name="mlm_probability", default=0.15, lower_bound=0.0, upper_bound=1.0, help="")
+
+# Train params
+flags.DEFINE_boolean(name="overwrite_output_dir", default=True, help="")
+flags.DEFINE_integer(name="num_train_epochs", default=10, help="")
+flags.DEFINE_integer(name="per_device_train_batch_size", default=64, help="")
+flags.DEFINE_integer(name="save_steps", default=10_000, help="")
+flags.DEFINE_integer(name="save_total_limit", default=2, help="")
+
+
+def main(argv):
+    #wandb.login()
+
+    is_gpu = torch.cuda.is_available()
+
+    config = RobertaConfig(
+        vocab_size=FLAGS.vocab_size,
+        max_position_embeddings=FLAGS.max_position_embeddings,
+        num_attention_heads=FLAGS.num_attention_heads,
+        num_hidden_layers=FLAGS.num_hidden_layers,
+        type_vocab_size=FLAGS.type_vocab_size,
+        num_labels=2
+    )
+    
+    model = RobertaForRegression(config=config)
+    
+    
+    if FLAGS.tokenizer_path:
+        tokenizer_path = FLAGS.tokenizer_path
+    elif FLAGS.tokenizer_type.upper() == "BPE":
+        tokenizer_path = FLAGS.output_tokenizer_dir
+        if not os.path.isdir(tokenizer_path):
+            os.makedirs(tokenizer_path)
+        
+        tokenizer = ByteLevelBPETokenizer()
+        tokenizer.train(files=FLAGS.dataset_path, vocab_size=FLAGS.vocab_size, min_frequency=FLAGS.BPE_min_frequency, special_tokens=["<s>","<pad>","</s>","<unk>","<mask>"])
+        tokenizer.save_model(tokenizer_path)
+    else:
+        raise TypeError("Please provide a tokenizer path if using the SMILES tokenizer")
+
+    tokenizer = RobertaTokenizerFast.from_pretrained(tokenizer_path, max_len=FLAGS.max_tokenizer_len)
+
+    dataset = RegressionDataset(tokenizer=tokenizer, file_path=FLAGS.dataset_path)
+
+    training_args = TrainingArguments(
+        output_dir=FLAGS.output_dir,
+        overwrite_output_dir=FLAGS.overwrite_output_dir,
+        num_train_epochs=FLAGS.num_train_epochs,
+        per_device_train_batch_size=FLAGS.per_device_train_batch_size,
+        save_steps=FLAGS.save_steps,
+        save_total_limit=FLAGS.save_total_limit,
+        fp16 = is_gpu, # fp16 only works on CUDA devices
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        data_collator=multitask_data_collator,
+        train_dataset=dataset,
+    )
+
+    trainer.train()
+    trainer.save_model(FLAGS.model_name)
+
+if __name__ == '__main__':
+    app.run(main)

--- a/chemberta/masked-lm/train_roberta_sequenceclass.py
+++ b/chemberta/masked-lm/train_roberta_sequenceclass.py
@@ -1,0 +1,124 @@
+""" Script for training a Roberta Masked-Language Model
+
+Usage [SMILES tokenizer]:
+    python train_roberta_regression.py --dataset_path=<DATASET_PATH> --output_dir=<OUTPUT_DIR> --model_name=<MODEL_NAME> --tokenizer_type=smiles --tokenizer_path="seyonec/SMILES_tokenized_PubChem_shard00_160k"
+    
+Usage [BPE tokenizer]:
+    python train_roberta_mlm.py --dataset_path=<DATASET_PATH> --output_dir=<OUTPUT_DIR> --model_name=<MODEL_NAME> --tokenizer_type=bpe
+"""
+    
+import torch
+import pandas as pd
+
+import os
+from absl import app
+from absl import flags
+
+import transformers
+
+import torch
+
+import wandb
+from transformers import RobertaConfig, RobertaTokenizerFast, RobertaForMaskedLM
+
+from chemberta.utils.roberta_regression import RobertaForRegression, RobertaForSequenceClassification
+from chemberta.utils.data_collators import multitask_data_collator
+from chemberta.utils.raw_text_dataset import RawTextDataset, RegressionDataset
+
+from transformers import DataCollatorForLanguageModeling
+from transformers import Trainer, TrainingArguments
+
+from tokenizers import ByteLevelBPETokenizer
+
+FLAGS = flags.FLAGS
+
+# RobertaConfig params
+flags.DEFINE_integer(name="vocab_size", default=52_000, help="")
+flags.DEFINE_integer(name="max_position_embeddings", default=512, help="")
+flags.DEFINE_integer(name="num_attention_heads", default=12, help="")
+flags.DEFINE_integer(name="num_hidden_layers", default=6, help="")
+flags.DEFINE_integer(name="type_vocab_size", default=1, help="")
+
+# Tokenizer params
+flags.DEFINE_enum(name="tokenizer_type", default="smiles", enum_values=["smiles", "bpe", "SMILES", "BPE"], help="")
+flags.DEFINE_string(name="tokenizer_path", default="seyonec/SMILES_tokenized_PubChem_shard00_160k", help="")
+flags.DEFINE_integer(name="BPE_min_frequency", default=2, help="")
+flags.DEFINE_string(name="output_tokenizer_dir", default="tokenizer_dir", help="")
+flags.DEFINE_integer(name="max_tokenizer_len", default=512, help="")
+flags.DEFINE_integer(name="tokenizer_block_size", default=512, help="")
+
+
+# Dataset params
+flags.DEFINE_string(name="dataset_path", default="pubchem-10m.txt", help="")
+flags.DEFINE_string(name="output_dir", default="PubChem_10M_SMILES_Tokenizer", help="")
+flags.DEFINE_string(name="model_name", default="PubChem_10M_SMILES_Tokenizer", help="")
+
+# MLM params
+flags.DEFINE_float(name="mlm_probability", default=0.15, lower_bound=0.0, upper_bound=1.0, help="")
+flags.DEFINE_integer(name="num_labels", default=1, help="")
+
+# Train params
+flags.DEFINE_boolean(name="overwrite_output_dir", default=True, help="")
+flags.DEFINE_integer(name="num_train_epochs", default=10, help="")
+flags.DEFINE_integer(name="per_device_train_batch_size", default=8, help="")
+flags.DEFINE_integer(name="save_steps", default=10_000, help="")
+flags.DEFINE_integer(name="save_total_limit", default=2, help="")
+
+
+def main(argv):
+    #wandb.login()
+
+    is_gpu = torch.cuda.is_available()
+
+    config = RobertaConfig(
+        vocab_size=FLAGS.vocab_size,
+        max_position_embeddings=FLAGS.max_position_embeddings,
+        num_attention_heads=FLAGS.num_attention_heads,
+        num_hidden_layers=FLAGS.num_hidden_layers,
+        type_vocab_size=FLAGS.type_vocab_size,
+        num_labels=FLAGS.num_labels
+    )
+
+    model = RobertaForSequenceClassification(config=config)
+
+    if FLAGS.tokenizer_path:
+        tokenizer_path = FLAGS.tokenizer_path
+    elif FLAGS.tokenizer_type.upper() == "BPE":
+        tokenizer_path = FLAGS.output_tokenizer_dir
+        if not os.path.isdir(tokenizer_path):
+            os.makedirs(tokenizer_path)
+        
+        tokenizer = ByteLevelBPETokenizer()
+        tokenizer.train(files=FLAGS.dataset_path, vocab_size=FLAGS.vocab_size, min_frequency=FLAGS.BPE_min_frequency, special_tokens=["<s>","<pad>","</s>","<unk>","<mask>"])
+        tokenizer.save_model(tokenizer_path)
+    else:
+        raise TypeError("Please provide a tokenizer path if using the SMILES tokenizer")
+
+    print("making tokenizer")
+    tokenizer = RobertaTokenizerFast.from_pretrained(tokenizer_path, max_len=FLAGS.max_tokenizer_len)
+    print("making dataset")
+    dataset = RegressionDataset(tokenizer=tokenizer, file_path=FLAGS.dataset_path, block_size=FLAGS.tokenizer_block_size)
+
+    training_args = TrainingArguments(
+        output_dir=FLAGS.output_dir,
+        overwrite_output_dir=FLAGS.overwrite_output_dir,
+        num_train_epochs=FLAGS.num_train_epochs,
+        per_device_train_batch_size=FLAGS.per_device_train_batch_size,
+        save_steps=FLAGS.save_steps,
+        save_total_limit=FLAGS.save_total_limit,
+        fp16 = is_gpu, # fp16 only works on CUDA devices
+    )
+
+    print("training")
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        data_collator=multitask_data_collator,
+        train_dataset=dataset,
+    )
+
+    trainer.train()
+    trainer.save_model(FLAGS.model_name)
+
+if __name__ == '__main__':
+    app.run(main)

--- a/chemberta/masked-lm/train_roberta_sequenceclass.py
+++ b/chemberta/masked-lm/train_roberta_sequenceclass.py
@@ -1,10 +1,9 @@
-""" Script for training a Roberta Masked-Language Model
+""" Script for training a Roberta Sequence Classification Model
+
+Note: This script is not currently in use but it mostly just calls some of the vanilla sequence classification code to use as reference.
 
 Usage [SMILES tokenizer]:
-    python train_roberta_regression.py --dataset_path=<DATASET_PATH> --output_dir=<OUTPUT_DIR> --model_name=<MODEL_NAME> --tokenizer_type=smiles --tokenizer_path="seyonec/SMILES_tokenized_PubChem_shard00_160k"
-    
-Usage [BPE tokenizer]:
-    python train_roberta_mlm.py --dataset_path=<DATASET_PATH> --output_dir=<OUTPUT_DIR> --model_name=<MODEL_NAME> --tokenizer_type=bpe
+    python train_roberta_sequenceclass.py --dataset_path=<DATASET_PATH> --output_dir=<OUTPUT_DIR> --model_name=<MODEL_NAME> --tokenizer_type=<smiles/bpe>
 """
     
 import torch

--- a/chemberta/utils/data_collators.py
+++ b/chemberta/utils/data_collators.py
@@ -1,0 +1,37 @@
+import torch
+from typing import List, Dict
+from transformers.data.data_collator import InputDataClass
+from transformers.tokenization_utils_base import BatchEncoding
+
+def multitask_data_collator(features: List[InputDataClass]) -> Dict[str, torch.Tensor]:
+    """
+    Very simple data collator that simply collates batches of dict-like objects and performs special handling for
+    potential keys named:
+        - ``label``: handles a single value (int or float) per object
+        - ``label_ids``: handles a list of values per object
+    Does not do any additional preprocessing: property names of the input object will be used as corresponding inputs
+    to the model. See glue and ner for example of how it's useful.
+    """
+
+    # In this function we'll make the assumption that all `features` in the batch
+    # have the same attributes.
+    # So we will look at the first element as a proxy for what attributes exist
+    # on the whole batch.
+    if not isinstance(features[0], (dict, BatchEncoding)):
+        features = [vars(f) for f in features]
+
+    first = features[0]
+    batch = {}
+
+    batch["labels"] = torch.stack([f["label"] for f in features])
+
+    # Handling of all other possible keys.
+    # Again, we will use the first element to figure out which key/values are not None for this model.
+    for k, v in first.items():
+        if k != "label" and v is not None and not isinstance(v, str):
+            if isinstance(v, torch.Tensor):
+                batch[k] = torch.stack([f[k] for f in features])
+            else:
+                batch[k] = torch.tensor([f[k] for f in features])
+
+    return batch

--- a/chemberta/utils/data_collators.py
+++ b/chemberta/utils/data_collators.py
@@ -5,18 +5,14 @@ from transformers.tokenization_utils_base import BatchEncoding
 
 def multitask_data_collator(features: List[InputDataClass]) -> Dict[str, torch.Tensor]:
     """
-    Very simple data collator that simply collates batches of dict-like objects and performs special handling for
-    potential keys named:
-        - ``label``: handles a single value (int or float) per object
-        - ``label_ids``: handles a list of values per object
-    Does not do any additional preprocessing: property names of the input object will be used as corresponding inputs
-    to the model. See glue and ner for example of how it's useful.
+    Very simple data collator that simply collates batches of dict-like objects and performs special handling for potential keys named label
     """
 
     # In this function we'll make the assumption that all `features` in the batch
     # have the same attributes.
     # So we will look at the first element as a proxy for what attributes exist
     # on the whole batch.
+    print(f"collating {len(features)} items")
     if not isinstance(features[0], (dict, BatchEncoding)):
         features = [vars(f) for f in features]
 
@@ -33,5 +29,5 @@ def multitask_data_collator(features: List[InputDataClass]) -> Dict[str, torch.T
                 batch[k] = torch.stack([f[k] for f in features])
             else:
                 batch[k] = torch.tensor([f[k] for f in features])
-
+                
     return batch

--- a/chemberta/utils/raw_text_dataset.py
+++ b/chemberta/utils/raw_text_dataset.py
@@ -66,15 +66,10 @@ class RegressionDataset(Dataset):
     def __len__(self):
         return self.len
     
-    def pad(self, feature_embedding, length_when_padded=300):
-        return feature_embedding
-        #return feature_embedding + [0] * (length_when_padded - len(feature_embedding))
-
     def preprocess(self, line):
-        #print("preprocessing")
         batch_encoding = self.tokenizer(line[self.smiles_column], add_special_tokens=True, truncation=True, padding="max_length", max_length=self.block_size)
-        batch_encoding = {k: torch.tensor(self.pad(v)) for k,v in batch_encoding.items()}
         batch_encoding["label"] = torch.tensor([line[label_column] for label_column in self.label_columns])
+        batch_encoding = {k: torch.tensor(v) for k,v in batch_encoding.items()}
         
         return batch_encoding
 

--- a/chemberta/utils/raw_text_dataset.py
+++ b/chemberta/utils/raw_text_dataset.py
@@ -1,6 +1,7 @@
 import torch
 from torch.utils.data import Dataset
 from nlp import load_dataset
+import pandas as pd
 
 class RawTextDataset(Dataset):
     """
@@ -42,3 +43,25 @@ class RawTextDataset(Dataset):
         line = self.dataset[i]
         example = self.preprocess(line)
         return example
+
+# TODO: convert this dataset to lazy-loading
+class RegressionDataset(Dataset):
+    def __init__(self, tokenizer, file_path: str):
+        self.tokenizer = tokenizer
+
+        # TODO: try to use HuggingFace framework for this part
+        # TODO: don't assume the structure of the CSV
+        df = pd.read_csv(file_path)
+        sequences_to_embed = df.iloc[:,0].values.tolist()
+        labels = df.iloc[:,1:].values.tolist()
+
+        self.encodings = tokenizer(sequences_to_embed, truncation=True, padding=True)
+        self.labels = labels
+
+    def __getitem__(self, idx):
+        item = {key: torch.tensor(val[idx]) for key, val in self.encodings.items()}
+        item['label'] = torch.tensor(self.labels[idx])
+        return item
+
+    def __len__(self):
+        return len(self.labels)

--- a/chemberta/utils/raw_text_dataset.py
+++ b/chemberta/utils/raw_text_dataset.py
@@ -44,6 +44,7 @@ class RawTextDataset(Dataset):
         example = self.preprocess(line)
         return example
 
+
 class RegressionDataset(Dataset):
     def __init__(self, tokenizer, file_path: str, block_size:int):
         self.tokenizer = tokenizer
@@ -69,8 +70,9 @@ class RegressionDataset(Dataset):
     def __len__(self):
         return len(self.labels)
 
-# TODO: convert this dataset to lazy-loading
-class RegressionDatasetNew(Dataset):
+
+# This dataset is more efficient (supposedly) but has some issues
+class RegressionDatasetLazy(Dataset):
     def __init__(self, tokenizer, file_path: str, block_size: int):
         print("init dataset")
         self.tokenizer = tokenizer
@@ -104,12 +106,3 @@ class RegressionDatasetNew(Dataset):
         line = self.dataset[i]
         example = self.preprocess(line)
         return example    
-
-        # TODO: try to use HuggingFace framework for this part
-        # TODO: don't assume the structure of the CSV
-        #df = pd.read_csv(file_path)
-        #sequences_to_embed = df.iloc[:,0].values.tolist()
-        #labels = df.iloc[:,1:].values.tolist()
-
-        #self.encodings = tokenizer(sequences_to_embed, truncation=True, padding=True)
-        #self.labels = labels

--- a/chemberta/utils/roberta_regression.py
+++ b/chemberta/utils/roberta_regression.py
@@ -89,8 +89,8 @@ class RobertaForRegression(RobertaPreTrainedModel):
         ):
         
         outputs = self.roberta(
-            torch.tensor(input_ids),
-            attention_mask=torch.tensor(attention_mask),
+            input_ids,
+            attention_mask=attention_mask,
             token_type_ids=token_type_ids,
             position_ids=position_ids,
             head_mask=head_mask,
@@ -100,8 +100,8 @@ class RobertaForRegression(RobertaPreTrainedModel):
             return_dict=return_dict,
         )
     
-        sequence_output = outputs[0]
-        logits = self.classifier(sequence_output)
+        sequence_output = outputs.last_hidden_state # shape = (batch, seq_len, hidden_size)
+        logits = self.regression(sequence_output)
 
         return logits
 

--- a/chemberta/utils/roberta_regression.py
+++ b/chemberta/utils/roberta_regression.py
@@ -168,8 +168,8 @@ class RobertaForRegression(RobertaPreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         outputs = self.roberta(
-            input_ids, # torch.tensor ? 
-            attention_mask=attention_mask, # torch.tensor ?
+            input_ids,
+            attention_mask=attention_mask,
             token_type_ids=token_type_ids,
             position_ids=position_ids,
             head_mask=head_mask,

--- a/chemberta/utils/roberta_regression.py
+++ b/chemberta/utils/roberta_regression.py
@@ -1,0 +1,187 @@
+import math
+
+import torch
+import torch.nn as nn
+import torch.utils.checkpoint
+from torch.nn import CrossEntropyLoss, MSELoss
+from transformers import RobertaModel, PreTrainedModel
+from dataclasses import dataclass
+from transformers.file_utils import ModelOutput
+from typing import Optional, Tuple, List, Dict
+from transformers.tokenization_utils_base import BatchEncoding
+from transformers.models.roberta.modeling_roberta import RobertaPreTrainedModel
+from transformers.data.data_collator import InputDataClass
+
+
+class RobertaForRegression(RobertaPreTrainedModel):
+    _keys_to_ignore_on_load_missing = [r"position_ids"]
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.num_labels = config.num_labels
+
+        self.roberta = RobertaModel(config, add_pooling_layer=False)
+        self.regression = RobertaRegressionHead(config)
+
+        self.init_weights()
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        token_type_ids=None,
+        position_ids=None,
+        head_mask=None,
+        inputs_embeds=None,
+        labels=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+    ):
+        r"""
+        labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
+            Labels for computing the sequence classification/regression loss. Indices should be in :obj:`[0, ...,
+            config.num_labels - 1]`. If :obj:`config.num_labels == 1` a regression loss is computed (Mean-Square loss),
+            If :obj:`config.num_labels > 1` a classification loss is computed (Cross-Entropy).
+        """
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        outputs = self.roberta(
+            input_ids, # torch.tensor ? 
+            attention_mask=attention_mask, # torch.tensor ?
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+            inputs_embeds=inputs_embeds,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+        sequence_output = outputs[0]
+        logits = self.regression(sequence_output)
+
+        if labels is not None:
+            loss_fct = MSELoss()
+            loss = loss_fct(logits.view(-1), labels.view(-1))
+
+
+            if not return_dict:
+                output = (logits,) + outputs[2:]
+                return ((loss,) + output) if loss is not None else output
+
+        return RegressionOutput(
+            loss=loss,
+            logits=logits,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
+    
+    def get_predictions(self,
+        input_ids=None,
+        attention_mask=None,
+        token_type_ids=None,
+        position_ids=None,
+        head_mask=None,
+        inputs_embeds=None,
+        labels=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+        ):
+        
+        outputs = self.roberta(
+            torch.tensor(input_ids),
+            attention_mask=torch.tensor(attention_mask),
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+            inputs_embeds=inputs_embeds,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+    
+        sequence_output = outputs[0]
+        logits = self.classifier(sequence_output)
+
+        return logits
+
+    
+class RobertaRegressionHead(nn.Module):
+    """Head for multitask regression models."""
+
+    def __init__(self, config):
+        super(RobertaRegressionHead, self).__init__()
+        self.dense = nn.Linear(config.hidden_size, config.hidden_size)
+        self.dropout = nn.Dropout(config.hidden_dropout_prob)
+        self.out_proj = nn.Linear(config.hidden_size, config.num_labels)
+
+    def forward(self, features, **kwargs):
+        x = features[:, 0, :]  # take <s> token (equiv. to [CLS])
+        x = self.dropout(x)
+        x = self.dense(x)
+        x = torch.tanh(x)
+        x = self.dropout(x)
+        x = self.out_proj(x)
+        return x
+
+    
+@dataclass
+class RegressionOutput(ModelOutput):
+    """
+    Base class for outputs of regression models. Supports single and multi-task regression.
+
+    Args:
+        loss (:obj:`torch.FloatTensor` of shape :obj:`(1,)`, `optional`, returned when :obj:`labels` is provided)
+        logits (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, config.num_labels)`):
+            Regression scores for each task (before SoftMax).
+        hidden_states (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
+            Tuple of :obj:`torch.FloatTensor` (one for the output of the embeddings + one for the output of each layer)
+            of shape :obj:`(batch_size, sequence_length, hidden_size)`.
+            Hidden-states of the model at the output of each layer plus the initial embedding outputs.
+        attentions (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``output_attentions=True`` is passed or when ``config.output_attentions=True``):
+            Tuple of :obj:`torch.FloatTensor` (one for each layer) of shape :obj:`(batch_size, num_heads,
+            sequence_length, sequence_length)`.
+
+            Attentions weights after the attention softmax, used to compute the weighted average in the self-attention
+            heads.
+    """
+
+    loss: Optional[torch.FloatTensor] = None
+    logits: torch.FloatTensor = None
+    hidden_states: Optional[Tuple[torch.FloatTensor]] = None
+    attentions: Optional[Tuple[torch.FloatTensor]] = None
+
+
+def multitask_data_collator(features: List[InputDataClass]) -> Dict[str, torch.Tensor]:
+    """
+    Very simple data collator that simply collates batches of dict-like objects and performs special handling for
+    potential keys named:
+        - ``label``: handles a single value (int or float) per object
+        - ``label_ids``: handles a list of values per object
+    Does not do any additional preprocessing: property names of the input object will be used as corresponding inputs
+    to the model. See glue and ner for example of how it's useful.
+    """
+
+    # In this function we'll make the assumption that all `features` in the batch
+    # have the same attributes.
+    # So we will look at the first element as a proxy for what attributes exist
+    # on the whole batch.
+    if not isinstance(features[0], (dict, BatchEncoding)):
+        features = [vars(f) for f in features]
+
+    first = features[0]
+    batch = {}
+
+    batch["labels"] = torch.stack([f["label"] for f in features])
+
+    # Handling of all other possible keys.
+    # Again, we will use the first element to figure out which key/values are not None for this model.
+    for k, v in first.items():
+        if k != "label" and v is not None and not isinstance(v, str):
+            if isinstance(v, torch.Tensor):
+                batch[k] = torch.stack([f[k] for f in features])
+            else:
+                batch[k] = torch.tensor([f[k] for f in features])
+
+    return batch

--- a/chemberta/utils/roberta_regression.py
+++ b/chemberta/utils/roberta_regression.py
@@ -10,7 +10,7 @@ from transformers.file_utils import ModelOutput
 from typing import Optional, Tuple, List, Dict
 from transformers.models.roberta.modeling_roberta import RobertaPreTrainedModel
 
-# TAKEN DIRECTLY FROM HUGGINGFACE NOT MODIFIED
+
 class RobertaClassificationHead(nn.Module):
     """Head for sentence-level classification tasks."""
 
@@ -28,7 +28,6 @@ class RobertaClassificationHead(nn.Module):
         x = self.dropout(x)
         x = self.out_proj(x)
         return x
-
 
 
 @dataclass
@@ -58,6 +57,7 @@ class SequenceClassifierOutput(ModelOutput):
     logits: torch.FloatTensor = None
     hidden_states: Optional[Tuple[torch.FloatTensor]] = None
     attentions: Optional[Tuple[torch.FloatTensor]] = None
+
 
 class RobertaForSequenceClassification(RobertaPreTrainedModel):
     _keys_to_ignore_on_load_missing = [r"position_ids"]
@@ -130,6 +130,7 @@ class RobertaForSequenceClassification(RobertaPreTrainedModel):
             attentions=outputs.attentions,
         )
 
+
 class RobertaForRegression(RobertaPreTrainedModel):
     _keys_to_ignore_on_load_missing = [r"position_ids"]
 
@@ -201,44 +202,11 @@ class RobertaForRegression(RobertaPreTrainedModel):
             attentions=outputs.attentions,
         )
 
-
     def normalize_logits(self, tensor):
         return (tensor - self.norm_mean) / self.norm_std
 
-
     def unnormalize_logits(self, tensor):
         return (tensor * self.norm_std) + self.norm_mean
-
-
-    def get_predictions(self,
-        input_ids=None,
-        attention_mask=None,
-        token_type_ids=None,
-        position_ids=None,
-        head_mask=None,
-        inputs_embeds=None,
-        labels=None,
-        output_attentions=None,
-        output_hidden_states=None,
-        return_dict=None,
-        ):
-        
-        outputs = self.roberta(
-            input_ids,
-            attention_mask=attention_mask,
-            token_type_ids=token_type_ids,
-            position_ids=position_ids,
-            head_mask=head_mask,
-            inputs_embeds=inputs_embeds,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
-        )
-    
-        sequence_output = outputs.last_hidden_state # shape = (batch, seq_len, hidden_size)
-        logits = self.regression(sequence_output)
-
-        return logits
 
     
 class RobertaRegressionHead(nn.Module):

--- a/chemberta/utils/roberta_regression.py
+++ b/chemberta/utils/roberta_regression.py
@@ -177,6 +177,9 @@ class RobertaForRegression(RobertaPreTrainedModel):
         
         sequence_output = outputs.last_hidden_state # shape = (batch, seq_len, hidden_size)
         logits = self.regression(sequence_output)
+
+        if labels is None:
+            return logits
         
         if labels is not None:
             loss_fct = MSELoss()

--- a/chemberta/utils/roberta_regression.py
+++ b/chemberta/utils/roberta_regression.py
@@ -55,7 +55,8 @@ class RobertaForRegression(RobertaPreTrainedModel):
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
         )
-        sequence_output = outputs[0]
+        
+        sequence_output = outputs.last_hidden_state # shape = (batch, seq_len, hidden_size)
         logits = self.regression(sequence_output)
 
         if labels is not None:

--- a/chemberta/utils/roberta_regression.py
+++ b/chemberta/utils/roberta_regression.py
@@ -10,6 +10,125 @@ from transformers.file_utils import ModelOutput
 from typing import Optional, Tuple, List, Dict
 from transformers.models.roberta.modeling_roberta import RobertaPreTrainedModel
 
+# TAKEN DIRECTLY FROM HUGGINGFACE NOT MODIFIED
+class RobertaClassificationHead(nn.Module):
+    """Head for sentence-level classification tasks."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.dense = nn.Linear(config.hidden_size, config.hidden_size)
+        self.dropout = nn.Dropout(config.hidden_dropout_prob)
+        self.out_proj = nn.Linear(config.hidden_size, config.num_labels)
+
+    def forward(self, features, **kwargs):
+        x = features[:, 0, :]  # take <s> token (equiv. to [CLS])
+        x = self.dropout(x)
+        x = self.dense(x)
+        x = torch.tanh(x)
+        x = self.dropout(x)
+        x = self.out_proj(x)
+        return x
+
+
+
+@dataclass
+class SequenceClassifierOutput(ModelOutput):
+    """
+    Base class for outputs of sentence classification models.
+
+    Args:
+        loss (:obj:`torch.FloatTensor` of shape :obj:`(1,)`, `optional`, returned when :obj:`labels` is provided):
+            Classification (or regression if config.num_labels==1) loss.
+        logits (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, config.num_labels)`):
+            Classification (or regression if config.num_labels==1) scores (before SoftMax).
+        hidden_states (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
+            Tuple of :obj:`torch.FloatTensor` (one for the output of the embeddings + one for the output of each layer)
+            of shape :obj:`(batch_size, sequence_length, hidden_size)`.
+
+            Hidden-states of the model at the output of each layer plus the initial embedding outputs.
+        attentions (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``output_attentions=True`` is passed or when ``config.output_attentions=True``):
+            Tuple of :obj:`torch.FloatTensor` (one for each layer) of shape :obj:`(batch_size, num_heads,
+            sequence_length, sequence_length)`.
+
+            Attentions weights after the attention softmax, used to compute the weighted average in the self-attention
+            heads.
+    """
+
+    loss: Optional[torch.FloatTensor] = None
+    logits: torch.FloatTensor = None
+    hidden_states: Optional[Tuple[torch.FloatTensor]] = None
+    attentions: Optional[Tuple[torch.FloatTensor]] = None
+
+class RobertaForSequenceClassification(RobertaPreTrainedModel):
+    _keys_to_ignore_on_load_missing = [r"position_ids"]
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.num_labels = config.num_labels
+
+        self.roberta = RobertaModel(config, add_pooling_layer=False)
+        self.classifier = RobertaClassificationHead(config)
+
+        self.init_weights()
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        token_type_ids=None,
+        position_ids=None,
+        head_mask=None,
+        inputs_embeds=None,
+        labels=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+    ):
+        r"""
+        labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
+            Labels for computing the sequence classification/regression loss. Indices should be in :obj:`[0, ...,
+            config.num_labels - 1]`. If :obj:`config.num_labels == 1` a regression loss is computed (Mean-Square loss),
+            If :obj:`config.num_labels > 1` a classification loss is computed (Cross-Entropy).
+        """
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        outputs = self.roberta(
+            input_ids,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+            inputs_embeds=inputs_embeds,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+        sequence_output = outputs[0]
+        logits = self.classifier(sequence_output)
+        
+        if labels is None:
+            return logits
+ 
+        loss = None
+        if labels is not None:
+            if self.num_labels == 1:
+                #  We are doing regression
+                loss_fct = MSELoss()
+                loss = loss_fct(logits.view(-1), labels.view(-1))
+            else:
+                loss_fct = CrossEntropyLoss()
+                loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))
+
+        if not return_dict:
+            output = (logits,) + outputs[2:]
+            return ((loss,) + output) if loss is not None else output
+
+        return SequenceClassifierOutput(
+            loss=loss,
+            logits=logits,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
 
 class RobertaForRegression(RobertaPreTrainedModel):
     _keys_to_ignore_on_load_missing = [r"position_ids"]
@@ -58,7 +177,7 @@ class RobertaForRegression(RobertaPreTrainedModel):
         
         sequence_output = outputs.last_hidden_state # shape = (batch, seq_len, hidden_size)
         logits = self.regression(sequence_output)
-
+        
         if labels is not None:
             loss_fct = MSELoss()
             loss = loss_fct(logits.view(-1), labels.view(-1))

--- a/chemberta/utils/roberta_regression.py
+++ b/chemberta/utils/roberta_regression.py
@@ -60,7 +60,7 @@ class SequenceClassifierOutput(ModelOutput):
 
 
 class RobertaForSequenceClassification(RobertaPreTrainedModel):
-    _keys_to_ignore_on_load_missing = [r"position_ids"]
+    _keys_to_ignore_on_load_missing = ["position_ids"]
 
     def __init__(self, config):
         super().__init__(config)
@@ -84,7 +84,7 @@ class RobertaForSequenceClassification(RobertaPreTrainedModel):
         output_hidden_states=None,
         return_dict=None,
     ):
-        r"""
+        """
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
             Labels for computing the sequence classification/regression loss. Indices should be in :obj:`[0, ...,
             config.num_labels - 1]`. If :obj:`config.num_labels == 1` a regression loss is computed (Mean-Square loss),
@@ -132,7 +132,7 @@ class RobertaForSequenceClassification(RobertaPreTrainedModel):
 
 
 class RobertaForRegression(RobertaPreTrainedModel):
-    _keys_to_ignore_on_load_missing = [r"position_ids"]
+    _keys_to_ignore_on_load_missing = ["position_ids"]
 
     def __init__(self, config):
         super().__init__(config)
@@ -159,7 +159,7 @@ class RobertaForRegression(RobertaPreTrainedModel):
         output_hidden_states=None,
         return_dict=None,
     ):
-        r"""
+        """
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
             Labels for computing the sequence classification/regression loss. Indices should be in :obj:`[0, ...,
             config.num_labels - 1]`. If :obj:`config.num_labels == 1` a regression loss is computed (Mean-Square loss),


### PR DESCRIPTION
What's in the PR:
* Adds in code for RobertaForSequenceClassification into repo
* Makes variant of this for RobertaForRegression which handles single or multi-task regression. Also normalizes/unnormalizes the values of each task so we can do multiple tasks on different scales.
* Added regression dataset class that reads in data from a csv, keeps track of all labels, and the mean/std.dev of each task so they can be normalized. This dataset starts by embedding all the smiles which isn't the most efficient.
* Also added a lazy regression dataset which uses hugging face's lazy csv dataset loader but currently has some issues
* Data collator that works for multitask (the vanilla one assumes each label is a single integer)
* Made it so each model just returns logits when called without labels (for eval)

Testing:
* Sequence Classification has been able to easily overfit to a dataset that always has 1 label
* Multitask Regression has been able to overfit to a dataset that has multiple consistent labels

Next steps:
* Switch over to new lazy dataloader
* Get this to work when some labels are NaN
* Reduce the repeated code- maybe merge all training scripts into one since they are quite similar
* Get multi-task regression to learn a simple molecular property (MW maybe?)
* Misc. code cleaning / reorganization (these probably shouldn't all be in a masked-lm folder but don't wanna do too much in 1 PR)