### PR TITLE
Improvements to MLM script

### DIFF
--- a/chemberta/masked-lm/train_roberta_mlm.py
+++ b/chemberta/masked-lm/train_roberta_mlm.py
@@ -13,6 +13,7 @@ from absl import flags
 import transformers
 
 import torch
+from torch.utils.data import random_split
 
 import wandb
 from transformers import RobertaConfig
@@ -29,11 +30,12 @@ from tokenizers import ByteLevelBPETokenizer
 FLAGS = flags.FLAGS
 
 # RobertaConfig params
-flags.DEFINE_integer(name="vocab_size", default=52_000, help="")
-flags.DEFINE_integer(name="max_position_embeddings", default=512, help="")
-flags.DEFINE_integer(name="num_attention_heads", default=12, help="")
-flags.DEFINE_integer(name="num_hidden_layers", default=6, help="")
+flags.DEFINE_integer(name="vocab_size", default=600, help="")
+flags.DEFINE_integer(name="max_position_embeddings", default=515, help="") # This needs to be longer than max_tokenizer_len. max_len is currently 514 in seyonec/SMILES_tokenized_PubChem_shard00_160k
+flags.DEFINE_integer(name="num_attention_heads", default=1, help="")
+flags.DEFINE_integer(name="num_hidden_layers", default=1, help="")
 flags.DEFINE_integer(name="type_vocab_size", default=1, help="")
+flags.DEFINE_bool(name="fp16", default=True, help="Mixed precision.")
 
 # Tokenizer params
 flags.DEFINE_enum(name="tokenizer_type", default="smiles", enum_values=["smiles", "bpe", "SMILES", "BPE"], help="")
@@ -53,10 +55,13 @@ flags.DEFINE_string(name="model_name", default="PubChem_10M_SMILES_Tokenizer", h
 flags.DEFINE_float(name="mlm_probability", default=0.15, lower_bound=0.0, upper_bound=1.0, help="")
 
 # Train params
+flags.DEFINE_float(name="frac_train", default=0.95, help="")
+flags.DEFINE_integer(name="eval_steps", default=1000, help="")
+flags.DEFINE_integer(name="logging_steps", default=100, help="")
 flags.DEFINE_boolean(name="overwrite_output_dir", default=True, help="")
-flags.DEFINE_integer(name="num_train_epochs", default=10, help="")
+flags.DEFINE_integer(name="num_train_epochs", default=1, help="")
 flags.DEFINE_integer(name="per_device_train_batch_size", default=64, help="")
-flags.DEFINE_integer(name="save_steps", default=10_000, help="")
+flags.DEFINE_integer(name="save_steps", default=10000, help="")
 flags.DEFINE_integer(name="save_total_limit", default=2, help="")
 
 
@@ -92,26 +97,37 @@ def main(argv):
     model.num_parameters()
 
     dataset = RawTextDataset(tokenizer=tokenizer, file_path=FLAGS.dataset_path, block_size=FLAGS.tokenizer_block_size)
+    
+    train_size = max(int(FLAGS.frac_train * len(dataset)), 1)
+    eval_size = len(dataset) - train_size
+    print(f"Train size: {train_size}")
+    print(f"Eval size: {eval_size}")
+    
+    train_dataset, eval_dataset = random_split(dataset, [train_size, eval_size])
 
     data_collator = DataCollatorForLanguageModeling(
         tokenizer=tokenizer, mlm=True, mlm_probability=FLAGS.mlm_probability
     )
 
     training_args = TrainingArguments(
+        evaluation_strategy="steps",
+        eval_steps=FLAGS.eval_steps,
+        logging_steps=FLAGS.logging_steps,
         output_dir=FLAGS.output_dir,
         overwrite_output_dir=FLAGS.overwrite_output_dir,
         num_train_epochs=FLAGS.num_train_epochs,
         per_device_train_batch_size=FLAGS.per_device_train_batch_size,
         save_steps=FLAGS.save_steps,
         save_total_limit=FLAGS.save_total_limit,
-        fp16 = is_gpu, # fp16 only works on CUDA devices
+        fp16 = is_gpu and FLAGS.fp16, # fp16 only works on CUDA devices
     )
 
     trainer = Trainer(
         model=model,
         args=training_args,
         data_collator=data_collator,
-        train_dataset=dataset,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
     )
 
     trainer.train()

--- a/chemberta/masked-lm/train_roberta_mlm.py
+++ b/chemberta/masked-lm/train_roberta_mlm.py
@@ -121,7 +121,6 @@ def main(argv):
         save_steps=FLAGS.save_steps,
         save_total_limit=FLAGS.save_total_limit,
         fp16 = is_gpu and FLAGS.fp16, # fp16 only works on CUDA devices
-        metric_for_best_model=
     )
 
     trainer = Trainer(

--- a/chemberta/masked-lm/train_roberta_mlm.py
+++ b/chemberta/masked-lm/train_roberta_mlm.py
@@ -11,6 +11,7 @@ from absl import app
 from absl import flags
 
 import transformers
+from transformers.trainer_callback import EarlyStoppingCallback
 
 import torch
 from torch.utils.data import random_split
@@ -120,6 +121,7 @@ def main(argv):
         save_steps=FLAGS.save_steps,
         save_total_limit=FLAGS.save_total_limit,
         fp16 = is_gpu and FLAGS.fp16, # fp16 only works on CUDA devices
+        metric_for_best_model=
     )
 
     trainer = Trainer(
@@ -128,6 +130,7 @@ def main(argv):
         data_collator=data_collator,
         train_dataset=train_dataset,
         eval_dataset=eval_dataset,
+        callbacks=[EarlyStoppingCallback(early_stopping_patience=1)],
     )
 
     trainer.train()


### PR DESCRIPTION
- Added an eval split with configurable `frac_train`
- Added more flags to customize logging and eval frequency
- Reduced default `vocab_size` to 600, which is a bit larger than the vocab in `seyonec/SMILES_tokenized_PubChem_shard00_160k`
- Added a flag to turn off mixed-precision since it was giving me some errors