### PR TITLE
Gpu and normalization fixes

### DIFF
--- a/chemberta/masked-lm/train_roberta_regression.py
+++ b/chemberta/masked-lm/train_roberta_regression.py
@@ -34,7 +34,7 @@ FLAGS = flags.FLAGS
 # RobertaConfig params
 flags.DEFINE_integer(name="vocab_size", default=512, help="")
 flags.DEFINE_integer(name="max_position_embeddings", default=515, help="")
-flags.DEFINE_integer(name="num_attention_heads", default=4, help="")
+flags.DEFINE_integer(name="num_attention_heads", default=6, help="")
 flags.DEFINE_integer(name="num_hidden_layers", default=6, help="")
 flags.DEFINE_integer(name="type_vocab_size", default=1, help="")
 
@@ -57,10 +57,10 @@ flags.DEFINE_float(name="mlm_probability", default=0.15, lower_bound=0.0, upper_
 
 # Train params
 flags.DEFINE_float(name="frac_train", default=0.95, help="")
-flags.DEFINE_integer(name="eval_steps", default=1000, help="")
+flags.DEFINE_integer(name="eval_steps", default=10, help="")
 flags.DEFINE_integer(name="logging_steps", default=10, help="")
 flags.DEFINE_boolean(name="overwrite_output_dir", default=True, help="")
-flags.DEFINE_integer(name="num_train_epochs", default=10, help="")
+flags.DEFINE_integer(name="num_train_epochs", default=100, help="")
 flags.DEFINE_integer(name="per_device_train_batch_size", default=64, help="")
 flags.DEFINE_integer(name="save_steps", default=100, help="")
 flags.DEFINE_integer(name="save_total_limit", default=2, help="")
@@ -110,6 +110,7 @@ def main(argv):
     )
 
     model = RobertaForRegression(config=config)
+    model = model.cuda()
 
     training_args = TrainingArguments(
         evaluation_strategy="steps",
@@ -132,7 +133,7 @@ def main(argv):
         data_collator=multitask_data_collator,
         train_dataset=dataset,
         eval_dataset=eval_dataset,
-        callbacks=[EarlyStoppingCallback(early_stopping_patience=1)],
+        callbacks=[EarlyStoppingCallback(early_stopping_patience=5)],
     )
 
     trainer.train()

--- a/chemberta/utils/roberta_regression.py
+++ b/chemberta/utils/roberta_regression.py
@@ -137,12 +137,14 @@ class RobertaForRegression(RobertaPreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
         self.num_labels = config.num_labels
-        self.norm_mean = torch.tensor(config.norm_mean)
+        self.register_buffer('norm_mean', torch.tensor(config.norm_mean))
+        self.register_buffer('norm_std', torch.tensor([label_std if label_std != 0 else 1 for label_std in config.norm_std]))
+        #self.norm_mean = torch.tensor(config.norm_mean)
         # Replace any 0 stddev norms with small constant (1e-8)
-        self.norm_std = torch.tensor([label_std if label_std != 0 else 1e-8 for label_std in config.norm_std])
-        if config.is_gpu:
-            self.norm_mean = self.norm_mean.cuda()
-            self.norm_std = self.norm_std.cuda()
+        #self.norm_std = torch.tensor([label_std if label_std != 0 else 1e-8 for label_std in config.norm_std])
+        #if config.is_gpu:
+        #    self.norm_mean = self.norm_mean.cuda()
+        #    self.norm_std = self.norm_std.cuda()
 
         self.roberta = RobertaModel(config, add_pooling_layer=False)
         self.regression = RobertaRegressionHead(config)
@@ -186,13 +188,14 @@ class RobertaForRegression(RobertaPreTrainedModel):
         logits = self.regression(sequence_output)
 
         if labels is None:
-
             return self.unnormalize_logits(logits)
 
         if labels is not None:
-            logits = self.normalize_logits(logits)
+            normalized_labels = self.normalize_logits(labels)
+            #logits = self.normalize_logits(logits)
             loss_fct = MSELoss()
-            loss = loss_fct(logits.view(-1), labels.view(-1))
+            loss = loss_fct(logits.view(-1), normalized_labels.view(-1))
+            #import pdb;pdb.set_trace()
 
             if not return_dict:
                 output = (logits,) + outputs[2:]
@@ -206,10 +209,13 @@ class RobertaForRegression(RobertaPreTrainedModel):
         )
 
     def normalize_logits(self, tensor):
+        #import pdb;pdb.set_trace()
         return (tensor - self.norm_mean) / self.norm_std
+        return (tensor - self.norm_mean.type_as(tensor)) / self.norm_std.type_as(tensor)
 
     def unnormalize_logits(self, tensor):
         return (tensor * self.norm_std) + self.norm_mean
+        return (tensor * self.norm_std.type_as(tensor)) + self.norm_mean.type_as(tensor)
 
 
 class RobertaRegressionHead(nn.Module):


### PR DESCRIPTION
* register buffers for norm_mean and norm_std so they end up on the proper GPUs (.cuda() always puts them on cuda:0 but the tensors they are interacting with aren't necessarily on that GPU when using multiple GPUs)
* switch normalization so we normalize the labels, not the logits
* std_dev is set to 1 not 1e-8 for targets where the stddev is 0 (aka all labels are the same) to minimize chance of overflows
* some slight improvements to misc. parameters 