### PR TITLE
fix regression ft

### DIFF
--- a/chemberta/finetune/finetune.py
+++ b/chemberta/finetune/finetune.py
@@ -118,6 +118,9 @@ def main(argv):
 def prune_state_dict(model_dir):
     """Remove problematic keys from state dictionary"""
     state_dict_path = os.path.join(model_dir, "pytorch_model.bin")
+    assert os.path.exists(
+        state_dict_path
+    ), f"No `pytorch_model.bin` file found in {model_dir}"
     loaded_state_dict = torch.load(state_dict_path)
     state_keys = loaded_state_dict.keys()
     keys_to_remove = [

--- a/chemberta/finetune/finetune.py
+++ b/chemberta/finetune/finetune.py
@@ -16,10 +16,10 @@ python finetune.py \
 
 """
 
-from collections import OrderedDict
 import json
 import os
 import shutil
+from collections import OrderedDict
 from glob import glob
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
Finetuning from MTR models was causing issues because of matching weights names. Essentially, pytorch would try to load the same weights even when the output shape had changed. This fix works by loading the `state_dict` manually, removing the weights for the last layer, and then passing that into the HuggingFace `.from_pretrained` method