### PR TITLE
only prune state dict if exists

### DIFF
--- a/chemberta/finetune/finetune.py
+++ b/chemberta/finetune/finetune.py
@@ -117,6 +117,9 @@ def main(argv):
 
 def prune_state_dict(model_dir):
     """Remove problematic keys from state dictionary"""
+    if not os.path.exists(os.path.join(model_dir, "pytorch_model.bin")):
+        return None
+
     state_dict_path = os.path.join(model_dir, "pytorch_model.bin")
     assert os.path.exists(
         state_dict_path


### PR DESCRIPTION
In the case that we're using a non-local dir, this means pruning won't break anything

Once we upload MTR dataset, this will need to be changed but for now is necessary to finetune on MLM