### PR TITLE
add delete flag to s3 upload

### DIFF
--- a/chemberta/finetune/finetune_multiple_with_freeze.py
+++ b/chemberta/finetune/finetune_multiple_with_freeze.py
@@ -26,7 +26,6 @@ python finetune.py --datasets=bbbp
 """
 import json
 import os
-import s3fs
 import shutil
 import subprocess
 import tempfile
@@ -188,6 +187,7 @@ def sync_with_s3(source_dir: str, target_dir: str):
             target_dir,
             "--acl",
             "bucket-owner-full-control",
+            "--delete",
         ]
     )
     return

--- a/chemberta/train/train_roberta.py
+++ b/chemberta/train/train_roberta.py
@@ -166,6 +166,7 @@ def main(argv):
                 full_cloud_dir,
                 "--acl",
                 "bucket-owner-full-control",
+                "--delete",
             ]
         )
 

--- a/chemberta/train/utils.py
+++ b/chemberta/train/utils.py
@@ -238,6 +238,7 @@ class AwsS3Callback(TrainerCallback):
                 self.s3_directory,
                 "--acl",
                 "bucket-owner-full-control",
+                "--delete",
             ]
         )
         return


### PR DESCRIPTION
Local saves only keep x most recent but cloud dir was keeping all, resulting in long and data-intensive pulls for resuming training